### PR TITLE
Add basic support for YugabyteDB.

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java
@@ -20,6 +20,7 @@ import org.flywaydb.core.api.logging.Log;
 import org.flywaydb.core.api.logging.LogFactory;
 import org.flywaydb.core.internal.database.base.BaseDatabaseType;
 
+import org.flywaydb.core.internal.database.yugabytedb.YugabyteDBDatabaseType;
 import org.flywaydb.core.internal.jdbc.JdbcUtils;
 import org.flywaydb.core.internal.util.StringUtils;
 
@@ -56,6 +57,7 @@ public class DatabaseTypeRegister {
             for (DatabaseType dt : loader) {
                 registeredDatabaseTypes.add(dt);
             }
+            registeredDatabaseTypes.add(new YugabyteDBDatabaseType());
 
             // Sort by preference order
             Collections.sort(registeredDatabaseTypes);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLConnection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLConnection.java
@@ -31,7 +31,7 @@ import java.util.concurrent.Callable;
 public class PostgreSQLConnection extends Connection<PostgreSQLDatabase> {
     private final String originalRole;
 
-    PostgreSQLConnection(PostgreSQLDatabase database, java.sql.Connection connection) {
+    protected PostgreSQLConnection(PostgreSQLDatabase database, java.sql.Connection connection) {
         super(database, connection);
 
         try {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLDatabase.java
@@ -53,7 +53,7 @@ public class PostgreSQLDatabase extends Database<PostgreSQLConnection> {
 
 
     @Override
-    public final void ensureSupported() {
+    public void ensureSupported() {
         ensureDatabaseIsRecentEnough("9.0");
 
         ensureDatabaseNotOlderThanOtherwiseRecommendUpgradeToFlywayEdition("9.5", org.flywaydb.core.internal.license.Edition.ENTERPRISE);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLSchema.java
@@ -38,7 +38,7 @@ public class PostgreSQLSchema extends Schema<PostgreSQLDatabase, PostgreSQLTable
      * @param database     The database-specific support.
      * @param name         The name of the schema.
      */
-    PostgreSQLSchema(JdbcTemplate jdbcTemplate, PostgreSQLDatabase database, String name) {
+    protected PostgreSQLSchema(JdbcTemplate jdbcTemplate, PostgreSQLDatabase database, String name) {
         super(jdbcTemplate, database, name);
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLTable.java
@@ -32,7 +32,7 @@ public class PostgreSQLTable extends Table<PostgreSQLDatabase, PostgreSQLSchema>
      * @param schema       The schema this table lives in.
      * @param name         The name of the table.
      */
-    PostgreSQLTable(JdbcTemplate jdbcTemplate, PostgreSQLDatabase database, PostgreSQLSchema schema, String name) {
+    protected PostgreSQLTable(JdbcTemplate jdbcTemplate, PostgreSQLDatabase database, PostgreSQLSchema schema, String name) {
         super(jdbcTemplate, database, schema, name);
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBConnection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBConnection.java
@@ -1,0 +1,16 @@
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLConnection;
+
+public class YugabyteDBConnection extends PostgreSQLConnection {
+
+    YugabyteDBConnection(YugabyteDBDatabase database, java.sql.Connection connection) {
+        super(database, connection);
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new YugabyteDBSchema(jdbcTemplate, (YugabyteDBDatabase) database, name);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabase.java
@@ -1,0 +1,32 @@
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLDatabase;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+
+import java.sql.Connection;
+
+public class YugabyteDBDatabase extends PostgreSQLDatabase {
+
+    public YugabyteDBDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    protected YugabyteDBConnection doGetConnection(Connection connection) {
+        return new YugabyteDBConnection(this, connection);
+    }
+
+    @Override
+    public void ensureSupported() {
+        // Checks the Postgres version
+        ensureDatabaseIsRecentEnough("11.2");
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        return false;
+    }
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabaseType.java
@@ -1,0 +1,50 @@
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLDatabaseType;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+
+import java.sql.Connection;
+
+
+public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType {
+    @Override
+    public String getName() {
+        return "YugabyteDB";
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url) {
+        return url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:");
+    }
+
+    @Override
+    public int getPriority() {
+        return 1;
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
+        if (databaseProductName.startsWith("PostgreSQL")) {
+            String selectVersionQueryOutput = getSelectVersionOutput(connection);
+            return selectVersionQueryOutput.contains("YB");
+        }
+        return false;
+    }
+
+    @Override
+    public Database createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        return new YugabyteDBDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
+        return new YugabyteDBParser(configuration, parsingContext);
+    }
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBParser.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBParser.java
@@ -1,0 +1,11 @@
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLParser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+
+public class YugabyteDBParser extends PostgreSQLParser {
+    protected YugabyteDBParser(Configuration configuration, ParsingContext parsingContext) {
+        super(configuration, parsingContext);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBSchema.java
@@ -1,0 +1,21 @@
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLSchema;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+public class YugabyteDBSchema extends PostgreSQLSchema {
+    /**
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param name         The name of the schema.
+     */
+    public YugabyteDBSchema(JdbcTemplate jdbcTemplate, YugabyteDBDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new YugabyteDBTable(jdbcTemplate, (YugabyteDBDatabase) database, this, tableName);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBTable.java
@@ -1,0 +1,16 @@
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLTable;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+public class YugabyteDBTable extends PostgreSQLTable {
+    /**
+     * @param jdbcTemplate The JDBC template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param schema       The schema this table lives in.
+     * @param name         The name of the table.
+     */
+    public YugabyteDBTable(JdbcTemplate jdbcTemplate, YugabyteDBDatabase database, YugabyteDBSchema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/package-info.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/package-info.java
@@ -1,0 +1,1 @@
+package org.flywaydb.core.internal.database.yugabytedb;


### PR DESCRIPTION
Added support for YugabyteDB by extending the existing API implementation of PostgreSQL.

APIs overridden in YugabyteDB:

1. Database.ensureSupported()
2. Database.supportsDdlTransactions() - YugabyteDB does not support it (even though it does not throw an error if a DDL is run inside an explicit transaction).
3. BaseDatabaseType.handlesJDBCUrl()
4. BaseDatabaseType.handlesDatabaseProductNameAndVersion()
5. BaseDatabaseType.getPriority()
6. BaseDatabaseType.getName()

No need to update pom file to add maven coordinates of YugabyteDB-specific driver, since YugabyteDB works with PostgreSQL driver which is already shipped with Flyway distribution.

Tested the changes with commands: info, migrate and clean - as outlined in [this section](https://flywaydb.org/documentation/contribute/contributingDatabaseSupport#getting-started).

Screenshot of the test run via IDE is available [here](https://docs.google.com/document/d/19eXgtK4O6_hWw_ApoPlBAAGww6rvnuiF-ny6rgkm1G4/edit?usp=sharing).